### PR TITLE
Fix return types to allow generation of mono glue

### DIFF
--- a/fn_fractal.cpp
+++ b/fn_fractal.cpp
@@ -1,7 +1,7 @@
 #include "fn_fractal.h"
 
-FNFractal::FNFractal(FractalType type) {
-    _frac_type = type;
+FNFractal::FNFractal(int type) {
+    _frac_type = static_cast<FractalType>(type);
 
     switch(_frac_type) {
         case FractalType::FBm:
@@ -11,9 +11,9 @@ FNFractal::FNFractal(FractalType type) {
     }
 }
 
-FNFractal *FNFractal::new_fractal(int type) {
-    FractalType frac_type = static_cast<FractalType>(type);
-    return new FNFractal(frac_type);
+Ref<FNFractal> FNFractal::new_fractal(int type) {
+    Ref<FNFractal> fractal(new FNFractal(type));
+    return fractal;
 }
 
 void FNFractal::set_source(FNGenerator *src) {

--- a/fn_fractal.h
+++ b/fn_fractal.h
@@ -15,9 +15,9 @@ public:
 		PingPong
 	};
 
-	FNFractal(FractalType type);
+	FNFractal(int type);
 
-	static FNFractal* new_fractal(int type);
+	static Ref<FNFractal> new_fractal(int type);
 
 	void set_source(FNGenerator* src);
 	void set_gain(float value) const { _frac_node->SetGain(value); }
@@ -26,7 +26,7 @@ public:
 	void set_lacunarity(float value) const { _frac_node->SetLacunarity(value); }
 
 	_FastNoise::SmartNode<_FastNoise::Generator> _get_smart_node() const override {
-		 return _frac_node; 
+		 return _frac_node;
 	}
 
 protected:

--- a/fn_generator.cpp
+++ b/fn_generator.cpp
@@ -5,8 +5,8 @@ FNGenerator::FNGenerator(int type) {
     _init_node();
 }
 
-FNGenerator *FNGenerator::new_generator(int type) {
-    return new FNGenerator(type);
+Ref<FNGenerator> FNGenerator::new_generator(int type) {
+    return Ref<FNGenerator>(new FNGenerator(type));
 }
 
 PackedFloat32Array FNGenerator::gen_uniform_grid_2D(

--- a/fn_generator.h
+++ b/fn_generator.h
@@ -25,7 +25,7 @@ public:
 
     FNGenerator(int type);
 
-    static FNGenerator* new_generator(int type);
+    static Ref<FNGenerator> new_generator(int type);
 
     PackedFloat32Array gen_uniform_grid_2D(
         int x_start, int y_start,


### PR DESCRIPTION
- Changed return type of FNFractal::new_fractal to be a Ref<FNFractal> rather than raw pointer.
- Changed return type of FNGenerator::new_generator to be a Ref<FNGenerator> rather than raw pointer.